### PR TITLE
Add 'prefer_forwarded' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 /composer.lock
 /build
 /.php_cs.cache
+.idea/

--- a/test/RateLimitTest.php
+++ b/test/RateLimitTest.php
@@ -27,6 +27,7 @@ class RateLimitTest extends \PHPUnit_Framework_TestCase
                 'ip_reset_time' => 10,
                 'api_header' => 'X-Api-Key',
                 'trust_forwarded' => true,
+                'prefer_forwarded' => false,
             ],
         ]);
         //$factory = new RateLimitFactory();


### PR DESCRIPTION
* Add an option to favour forwarded headers over real ones
* Simplify existing IP choice logic