### PR TITLE
Add PHP 8.0 and 8.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,6 @@ matrix:
     - php: 8.0
       env:
         - DEPS=latest
-    - php: 8.1
-      env:
-        - DEPS=lowest
-    - php: 8.1
-      env:
-        - DEPS=locked
-    - php: 8.1
-      env:
-        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,33 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
+      env:
+        - DEPS=locked
+    - php: 7.4
+      env:
+        - DEPS=latest
+    - php: 8.0
+      env:
+        - DEPS=lowest
+    - php: 8.0
+      env:
+        - DEPS=locked
+    - php: 8.0
+      env:
+        - DEPS=latest
+    - php: 8.1
+      env:
+        - DEPS=lowest
+    - php: 8.1
+      env:
+        - DEPS=locked
+    - php: 8.1
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,6 @@ env:
 
 matrix:
   include:
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=locked
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=locked
-    - php: 7.3
-      env:
-        - DEPS=latest
     - php: 7.4
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
         "psr/container": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "mezzio/mezzio-problem-details": "^1.0",
-        "laminas/laminas-diactoros": "^1.8.6 || ^2.0",
+        "laminas/laminas-diactoros": "^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0",
+        "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.4",
         "php-coveralls/php-coveralls": "^2.1",
         "doctrine/coding-standard": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,12 @@
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0",
-        "squizlabs/php_codesniffer": "^3.4",
-        "php-coveralls/php-coveralls": "^2.1",
         "doctrine/coding-standard": "^9.0",
-        "phpstan/phpstan": "^1.2"
+        "php-coveralls/php-coveralls": "^2.1",
+        "phpstan/phpstan": "^1.2",
+        "phpunit/php-token-stream": "^4.0.4",
+        "phpunit/phpunit": "^9.0",
+        "squizlabs/php_codesniffer": "^3.4"
     },
     "license": "BSD-3-Clause",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "los/los-rate-limit",
     "description": "Rate Limit Middleware for PHP",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "psr/http-message": "^1.0",
         "psr/container": "^1.0",
         "psr/http-server-middleware": "^1.0",
@@ -14,8 +14,8 @@
         "phpunit/phpunit": "^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.4",
         "php-coveralls/php-coveralls": "^2.1",
-        "doctrine/coding-standard": "^6.0",
-        "phpstan/phpstan": "^0.11.12"
+        "doctrine/coding-standard": "^9.0",
+        "phpstan/phpstan": "^1.2"
     },
     "license": "BSD-3-Clause",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
         "psr/container": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "mezzio/mezzio-problem-details": "^1.0",
-        "laminas/laminas-diactoros": "^2.0",
+        "laminas/laminas-diactoros": "^1.8.6 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.4",
         "php-coveralls/php-coveralls": "^2.1",
         "doctrine/coding-standard": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "los/los-rate-limit",
     "description": "Rate Limit Middleware for PHP",
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "psr/http-message": "^1.0",
         "psr/container": "^1.0",
         "psr/http-server-middleware": "^1.0",


### PR DESCRIPTION
Given changes in libraries this depends on, out of necessity this also drops PHP < 7.4 support.

PHP 7.3's last day of security support is this Monday. https://www.php.net/supported-versions.php