### PR TITLE
Allow using hashed IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ composer require los/los-rate-limit
             'reset_time' => 3600,
         ],
     ],
+    'hash_ips' => false,
+    'hash_salt' => 'Los%Rate',
 ]
 ```
 
@@ -71,6 +73,11 @@ composer require los/los-rate-limit
 * `forwarded_ip_index` If null (default), the first plausible IP in an XFF header (reading left to right) is used. If numeric, only a specific index of IP is used. Use `-2` to get the penultimate IP from the list, which could make sense if the header always ends `...<client_ip>, <router_ip>`. Or use `0` to use only the first IP (stopping if it's not valid). Like `prefer_forwarded`, this only makes sense if your app's always reached through a predictable hop that controls the header - remember these are easily spoofed on the initial request.
 * `keys` Specify different max_requests/reset_time per api key
 * `ips` Specify different max_requests/reset_time per IP
+* `hash_ips` Enable the hashing of IP addresses before storing them. This is particularly useful when using a 
+  filesystem-based cache implementation and working with IPv6 addresses. A salted MD5-hash will be used if you set 
+  this to `true`.
+* `hash_salt' This setting allows you to optionally define a custom salt when using hashed IP addresses. Only 
+  effective when `hash_ips` is `true`.
 
 The values above indicate that the user can trigger 100 requests per hour.
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "autoload-dev": {
         "psr-4": {
-            "LosMiddlewareTest\\RateLimit\\": "tests/"
+            "LosMiddlewareTest\\RateLimit\\": "test/"
         }
     },
     "autoload": {

--- a/src/RateLimitMiddleware.php
+++ b/src/RateLimitMiddleware.php
@@ -21,6 +21,7 @@ use function count;
 use function explode;
 use function filter_var;
 use function is_array;
+use function md5;
 use function str_replace;
 use function time;
 
@@ -74,7 +75,11 @@ class RateLimitMiddleware implements MiddlewareInterface
                 throw new MissingRequirement('Could not detect the client IP');
             }
 
-            $key = str_replace('.', '-', $key);
+            if ($this->options['hash_ips'] === true) {
+                $key = $this->hashIp($key);
+            } else {
+                $key = str_replace('.', '-', $key);
+            }
         }
 
         $data = $this->storage->get($key);
@@ -171,6 +176,13 @@ class RateLimitMiddleware implements MiddlewareInterface
         }
 
         return null;
+    }
+
+    private function hashIp(string $ip) : string
+    {
+        $salt = $this->options['hash_salt'];
+
+        return md5($salt . $ip);
     }
 
     /**

--- a/src/RateLimitOptions.php
+++ b/src/RateLimitOptions.php
@@ -34,6 +34,8 @@ class RateLimitOptions extends ArrayObject
         ],
         'keys' => [],
         'ips' => [],
+        'hash_ips' => false,
+        'hash_salt' => 'Los%Rate',
     ];
 
     /**

--- a/test/HashIpsTest.php
+++ b/test/HashIpsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LosMiddlewareTest\RateLimit;
+
+use LosMiddleware\RateLimit\RateLimitMiddleware;
+use LosMiddleware\RateLimit\RateLimitOptions;
+use Psr\Http\Server\RequestHandlerInterface;
+use Laminas\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\ServerRequest;
+
+class HashIpsTest extends TestSetup
+{
+    protected function setUp() : void
+    {
+        $options = new RateLimitOptions([
+            'max_requests' => 2,
+            'reset_time' => 10,
+            'ip_max_requests' => 2,
+            'ip_reset_time' => 10,
+            'api_header' => 'X-Api-Key',
+            'trust_forwarded' => true,
+            'prefer_forwarded' => false,
+            'forwarded_headers_allowed' => [
+                'Client-Ip',
+                'Forwarded',
+                'Forwarded-For',
+                'X-Cluster-Client-Ip',
+                'X-Forwarded',
+                'X-Forwarded-For',
+            ],
+            'forwarded_ip_index' => null,
+            'hash_ips' => true,
+        ]);
+
+        $problemResponse = $this->getMockProblemResponse();
+        $storage = $this->getMockStorage();
+        $this->middleware = new RateLimitMiddleware($storage, $problemResponse, $options);
+    }
+
+    public function testHashIp()
+    {
+        $defaultSalt = 'Los%Rate';
+        $clientIp = '192.168.1.1';
+
+        $request = new ServerRequest(['REMOTE_ADDR' => '127.0.0.1']);
+        $request = $request->withHeader('X-Forwarded-For', $clientIp);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn(new JsonResponse([]));
+        $this->middleware->process($request, $handler);
+
+        $this->assertArrayHasKey(\md5($defaultSalt . $clientIp), $this->cache);
+    }
+}

--- a/test/RateLimitTest.php
+++ b/test/RateLimitTest.php
@@ -99,6 +99,21 @@ class RateLimitTest extends TestSetup
         $this->assertSame(429, $result->getStatusCode());
     }
 
+    public function testStoresUnhashedIps()
+    {
+        $clientIp = '192.168.1.1';
+        $expectedCacheKey = '192-168-1-1';
+
+        $request = new ServerRequest(['REMOTE_ADDR' => '127.0.0.1']);
+        $request = $request->withHeader('X-Forwarded-For', $clientIp);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn(new JsonResponse([]));
+        $this->middleware->process($request, $handler);
+
+        $this->assertArrayHasKey($expectedCacheKey, $this->cache);
+    }
+
     public function testReset()
     {
 //        $container = new Container('LosRateLimit');

--- a/test/RateLimitTest.php
+++ b/test/RateLimitTest.php
@@ -12,44 +12,8 @@ use Laminas\Diactoros\Response\JsonResponse;
 use Laminas\Diactoros\ServerRequest;
 use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
 
-class RateLimitTest extends TestCase
+class RateLimitTest extends TestSetup
 {
-    /** @var array */
-    private $cache = [];
-    /** @var RateLimitMiddleware */
-    private $middleware;
-
-    protected function setUp() : void
-    {
-        $options = new RateLimitOptions([
-            'max_requests' => 2,
-            'reset_time' => 10,
-            'ip_max_requests' => 2,
-            'ip_reset_time' => 10,
-            'api_header' => 'X-Api-Key',
-            'trust_forwarded' => true,
-            'prefer_forwarded' => false,
-            'forwarded_headers_allowed' => [
-                'Client-Ip',
-                'Forwarded',
-                'Forwarded-For',
-                'X-Cluster-Client-Ip',
-                'X-Forwarded',
-                'X-Forwarded-For',
-            ],
-            'forwarded_ip_index' => null,
-        ]);
-
-        $problemResponse = $this->createMock(ProblemDetailsResponseFactory::class);
-        $problemResponse->method('createResponseFromThrowable')->willReturn(new JsonResponse([], 429));
-
-        $storage = $this->createMock(CacheInterface::class);
-        $storage->method('get')->will($this->returnCallback([$this, 'getCache']));
-        $storage->method('set')->will($this->returnCallback([$this, 'setCache']));
-
-        $this->middleware = new RateLimitMiddleware($storage, $problemResponse, $options);
-    }
-
     public function testNeedIpOuApiKey()
     {
         $request = new ServerRequest();
@@ -156,22 +120,5 @@ class RateLimitTest extends TestCase
         $this->assertArrayHasKey(RateLimitMiddleware::HEADER_LIMIT, $result->getHeaders());
         $this->assertLessThanOrEqual(10, $result->getHeader(RateLimitMiddleware::HEADER_RESET)[0]);
         $this->assertSame(200, $result->getStatusCode());
-    }
-
-    /**
-     * @param null|mixed $default
-     * @return null|mixed
-     */
-    public function getCache(string $key, $default = null)
-    {
-        return $this->cache[$key] ?? $default;
-    }
-
-    /**
-     * @param mixed $value
-     */
-    public function setCache(string $key, $value) : void
-    {
-        $this->cache[$key] = $value;
     }
 }

--- a/test/TestSetup.php
+++ b/test/TestSetup.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace LosMiddlewareTest\RateLimit;
+
+use Laminas\Diactoros\Response\JsonResponse;
+use LosMiddleware\RateLimit\RateLimitMiddleware;
+use LosMiddleware\RateLimit\RateLimitOptions;
+use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+class TestSetup extends TestCase
+{
+    /** @var array */
+    protected $cache = [];
+
+    /** @var RateLimitMiddleware */
+    protected $middleware;
+
+    protected function setUp(): void
+    {
+        $options = new RateLimitOptions([
+            'max_requests' => 2,
+            'reset_time' => 10,
+            'ip_max_requests' => 2,
+            'ip_reset_time' => 10,
+            'api_header' => 'X-Api-Key',
+            'trust_forwarded' => true,
+            'prefer_forwarded' => false,
+            'forwarded_headers_allowed' => [
+                'Client-Ip',
+                'Forwarded',
+                'Forwarded-For',
+                'X-Cluster-Client-Ip',
+                'X-Forwarded',
+                'X-Forwarded-For',
+            ],
+            'forwarded_ip_index' => null,
+        ]);
+
+        $problemResponse = $this->getMockProblemResponse();
+        $storage = $this->getMockStorage();
+        $this->middleware = new RateLimitMiddleware(
+            $storage,
+            $problemResponse,
+            $options
+        );
+    }
+
+    /**
+     * @param null|mixed $default
+     *
+     * @return null|mixed
+     */
+    public function getCache(string $key, $default = null)
+    {
+        return $this->cache[$key] ?? $default;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setCache(string $key, $value): void
+    {
+        $this->cache[$key] = $value;
+    }
+
+    protected function getMockProblemResponse()
+    {
+        $problemResponse = $this->createMock(
+            ProblemDetailsResponseFactory::class
+        );
+        $problemResponse->method('createResponseFromThrowable')->willReturn(
+            new JsonResponse([], 429)
+        );
+
+        return $problemResponse;
+    }
+
+    protected function getMockStorage()
+    {
+        $storage = $this->createMock(CacheInterface::class);
+        $storage->method('get')->will(
+            $this->returnCallback([$this, 'getCache'])
+        );
+        $storage->method('set')->will(
+            $this->returnCallback([$this, 'setCache'])
+        );
+
+        return $storage;
+    }
+}


### PR DESCRIPTION
This PR introduces the option of hashing IP addresses before storing them. Similar to #7 this avoids problems when using a filesystem-based cache implementation, but also covers IPv6 addresses (as opposed to the IPv4-only covered by #7). The library's base functionality remains unchanged; the new feature is implemented via an opt-in configuration setting.

Using hashing instead of a regex-replacement has the added benefit of anonymizing user's addresses inside the cache and thus being compliant with data privacy norms.

The salted MD5 hashing algorithm used is a compromise between relative security of these user data and speed in order not to become a bottleneck.

I've added tests for both the default behaviour and the new behaviour with IP hashing enabled. In doing so, I've refactored the tests a little and fixed the PSR-4 root declaration for the test namespace.