### PR TITLE
Allow psr/container v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^8.1",
         "psr/http-message": "^1.0",
-        "psr/container": "^2.0",
+        "psr/container": "^1.0 || ^2.0",
         "psr/http-server-middleware": "^1.0",
         "mezzio/mezzio-problem-details": "^1.0",
         "laminas/laminas-diactoros": "^2.0",


### PR DESCRIPTION
As interface doesn't break we can use v1 because https://github.com/laminas/laminas-servicemanager still support only v1